### PR TITLE
add a config option for ignoring git SSL verification

### DIFF
--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -275,6 +275,8 @@ type GitSpec struct {
 	User string `json:"user,omitempty"`
 	// Once syncs initially and quits (use init container instead of sidecar)
 	Once bool `json:"once,omitempty"`
+	// Control how git submodules are synced (default recursive)
+	SubmoduleMode string `json:"submodules,omitempty"`
 	// Configure git to ignore ssl (for use with self-signed certs)
 	VerifySsl bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -275,8 +275,6 @@ type GitSpec struct {
 	User string `json:"user,omitempty"`
 	// Once syncs initially and quits (use init container instead of sidecar)
 	Once bool `json:"once,omitempty"`
-	// Control how git submodules are synced (default recursive)
-	SubmoduleMode string `json:"submodules,omitempty"`
 	// Configure git to ignore ssl (for use with self-signed certs)
 	VerifySsl *bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -278,7 +278,7 @@ type GitSpec struct {
 	// Control how git submodules are synced (default recursive)
 	SubmoduleMode string `json:"submodules,omitempty"`
 	// Configure git to ignore ssl (for use with self-signed certs)
-	VerifySsl bool `json:"verify,omitempty"`
+	VerifySsl *bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
 }

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -16,13 +16,14 @@
 package v1alpha1
 
 import (
+	"math/rand"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"math/rand"
 	"sigs.k8s.io/controller-reconciler/pkg/finalizer"
 	"sigs.k8s.io/controller-reconciler/pkg/status"
-	"time"
 )
 
 // defaults and constant strings
@@ -274,6 +275,8 @@ type GitSpec struct {
 	User string `json:"user,omitempty"`
 	// Once syncs initially and quits (use init container instead of sidecar)
 	Once bool `json:"once,omitempty"`
+	// Configure git to ignore ssl (for use with self-signed certs)
+	VerifySsl bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
 }

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -691,6 +691,10 @@ spec:
                     user:
                       description: User for git access
                       type: string
+                    verify:
+                      description: Configure git to ignore ssl (for use with self-signed
+                        certs)
+                      type: boolean
                   required:
                   - repo
                   type: object
@@ -930,6 +934,8 @@ spec:
               description: Spec for Flower component.
               properties:
                 enableroutes:
+                  description: 'enableroutes: true enables routes for the AirflowUI
+                    and CeleryUI'
                   type: boolean
                 image:
                   description: Image defines the Flower Docker image.
@@ -1437,6 +1443,8 @@ spec:
               description: Spec for Airflow UI component.
               properties:
                 enableroutes:
+                  description: 'enableroutes: true enables routes for the AirflowUI
+                    and CeleryUI'
                   type: boolean
                 image:
                   description: Image defines the AirflowUI Docker image.

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -691,6 +691,9 @@ spec:
                     user:
                       description: User for git access
                       type: string
+                    submodules:
+                      description: Git submodule sync mode ie. 'recursive,shallow,off'
+                      type: string
                     verify:
                       description: Configure git to ignore ssl (for use with self-signed
                         certs)

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -688,15 +688,16 @@ spec:
                     rev:
                       description: Rev is the git hash to be used for syncing
                       type: string
+                    submodules:
+                      description: Control how git submodules are synced (default
+                        recursive)
+                      type: string
                     user:
                       description: User for git access
                       type: string
-                    submodules:
-                      description: Git submodule sync mode ie. 'recursive,shallow,off'
-                      type: string
                     verify:
                       description: Configure git to ignore ssl (for use with self-signed
-                        certs)
+                        certs), false to ignore
                       type: boolean
                   required:
                   - repo

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -688,10 +688,6 @@ spec:
                     rev:
                       description: Rev is the git hash to be used for syncing
                       type: string
-                    submodules:
-                      description: Control how git submodules are synced (default
-                        recursive)
-                      type: string
                     user:
                       description: User for git access
                       type: string

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -623,12 +623,12 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 			{Name: "GIT_SYNC_USERNAME", Value: s.User},
 		}...)
 	}
-	if s.VerifySsl != nil {
+	if s.VerifySsl {
 		env = append(env, []corev1.EnvVar{
 			{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
 		}...)
 	}
-	if s.SubmoduleMode != nil {
+	if s.SubmoduleMode != "" {
 		env = append(env, []corev1.EnvVar{
 			{Name: "GIT_SYNC_SUBMODULES", Value: s.SubmoduleMode},
 		}...)

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -630,11 +630,6 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 			}...)
 		}
 	}
-	if s.SubmoduleMode != "" {
-		env = append(env, []corev1.EnvVar{
-			{Name: "GIT_SYNC_SUBMODULES", Value: s.SubmoduleMode},
-		}...)
-	}
 	if s.Once {
 		init = true
 	}

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -623,10 +623,12 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 			{Name: "GIT_SYNC_USERNAME", Value: s.User},
 		}...)
 	}
-	if s.VerifySsl {
-		env = append(env, []corev1.EnvVar{
-			{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
-		}...)
+	if s.VerifySsl != nil {
+		if *s.VerifySsl == false {
+			env = append(env, []corev1.EnvVar{
+				{Name: "GIT_SSL_NO_VERIFY", Value: "true"},
+			}...)
+		}
 	}
 	if s.SubmoduleMode != "" {
 		env = append(env, []corev1.EnvVar{

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -615,14 +615,22 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 		{Name: "GIT_SYNC_BRANCH", Value: s.Branch},
 		{Name: "GIT_SYNC_ONE_TIME", Value: strconv.FormatBool(s.Once)},
 		{Name: "GIT_SYNC_REV", Value: s.Rev},
-		{Name: "GIT_SYNC_SUBMODULES", Value: s.SubmoduleMode},
-		{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
 	}
 	if s.CredSecretRef != nil {
 		env = append(env, []corev1.EnvVar{
 			{Name: "GIT_SYNC_PASSWORD",
 				ValueFrom: envFromSecret(s.CredSecretRef.Name, "password")},
 			{Name: "GIT_SYNC_USERNAME", Value: s.User},
+		}...)
+	}
+	if s.VerifySsl != nil {
+		env = append(env, []corev1.EnvVar{
+			{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
+		}...)
+	}
+	if s.SubmoduleMode != nil {
+		env = append(env, []corev1.EnvVar{
+			{Name: "GIT_SYNC_SUBMODULES", Value: s.SubmoduleMode},
 		}...)
 	}
 	if s.Once {

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -615,6 +615,7 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 		{Name: "GIT_SYNC_BRANCH", Value: s.Branch},
 		{Name: "GIT_SYNC_ONE_TIME", Value: strconv.FormatBool(s.Once)},
 		{Name: "GIT_SYNC_REV", Value: s.Rev},
+		{Name: "GIT_SYNC_SUBMODULES", Value: s.SubmoduleMode},
 		{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
 	}
 	if s.CredSecretRef != nil {

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -615,6 +615,7 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 		{Name: "GIT_SYNC_BRANCH", Value: s.Branch},
 		{Name: "GIT_SYNC_ONE_TIME", Value: strconv.FormatBool(s.Once)},
 		{Name: "GIT_SYNC_REV", Value: s.Rev},
+		{Name: "GIT_SSL_NO_VERIFY", Value: strconv.FormatBool(s.VerifySsl)},
 	}
 	if s.CredSecretRef != nil {
 		env = append(env, []corev1.EnvVar{


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Git SSL verification as optional.

## Description

In certain deployments it might be useful to allow the user to configure if git does SSL verification or not, specifically in environments where the IT department (or whoever hosts git) uses self-signed certs. What this change does is add a config option to the AirflowCluster CRD that sets `GIT_SSL_NO_VERIFY=true` in the `git-sync` container. This was the quickest way I could figure out how to persist this change, as modifications to the stateful sets that the operator deploys are not persisted.

In the future it might be useful to have the git-sync container consume the `ca.crt` field of an OpenShift secret in order to use a custom certificate, but it's unclear how to do that (at least while continuing to use `git-sync` as a sidecar/init contianer for dags).

Edit: There's an upstream PR in `git-sync` that might make this possible soon: https://github.com/kubernetes/git-sync/pull/240, once it's merged we can modify the pod spec in a way to mount a volume based on a secret field, and have it consumed via config injection.

Thoughts, opinions, criticisms welcome!
