### PR TITLE
update git-sync container and make it configurable

### DIFF
--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -16,13 +16,14 @@
 package v1alpha1
 
 import (
+	"math/rand"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"math/rand"
 	"sigs.k8s.io/controller-reconciler/pkg/finalizer"
 	"sigs.k8s.io/controller-reconciler/pkg/status"
-	"time"
 )
 
 // defaults and constant strings
@@ -35,8 +36,8 @@ const (
 	defaultWorkerImage      = "gcr.io/airflow-operator/airflow"
 	defaultSchedulerImage   = "gcr.io/airflow-operator/airflow"
 	defaultFlowerImage      = "gcr.io/airflow-operator/airflow"
-	GitsyncImage            = "gcr.io/google_containers/git-sync"
-	GitsyncVersion          = "v3.0.1"
+	GitsyncImage            = "k8s.gcr.io/git-sync/git-sync"
+	GitsyncVersion          = "v3.2.2"
 	GCSsyncImage            = "gcr.io/cloud-airflow-releaser/gcs-syncd"
 	GCSsyncVersion          = "cloud_composer_service_2018-05-23-RC0"
 	ExecutorLocal           = "Local"
@@ -276,6 +277,9 @@ type GitSpec struct {
 	Once bool `json:"once,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
+	// git-sync image + tag to use
+	SyncImage   string `json:"sync-image,omitempty"`
+	SyncVersion string `json:"sync-tag,omitempty"`
 }
 
 func (s *GitSpec) validate(fp *field.Path) field.ErrorList {

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -280,9 +280,9 @@ type GitSpec struct {
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
 	// git-sync image config + tag to use
-	SyncImage   string            `json:"sync-image,omitempty"`
-	SyncVersion string            `json:"sync-tag,omitempty"`
-	SyncEnv     map[string]string `json:"sync-env,omitempty"`
+	SyncImage   string            `json:"syncImage,omitempty"`
+	SyncVersion string            `json:"syncTag,omitempty"`
+	SyncEnv     map[string]string `json:"syncEnv,omitempty"`
 }
 
 func (s *GitSpec) validate(fp *field.Path) field.ErrorList {

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -279,9 +279,10 @@ type GitSpec struct {
 	VerifySsl *bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
-	// git-sync image + tag to use
-	SyncImage   string `json:"sync-image,omitempty"`
-	SyncVersion string `json:"sync-tag,omitempty"`
+	// git-sync image config + tag to use
+	SyncImage   string            `json:"sync-image,omitempty"`
+	SyncVersion string            `json:"sync-tag,omitempty"`
+	SyncEnv     map[string]string `json:"sync-env,omitempty"`
 }
 
 func (s *GitSpec) validate(fp *field.Path) field.ErrorList {

--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -263,6 +263,13 @@ func (s *GCSSpec) validate(fp *field.Path) field.ErrorList {
 	return errs
 }
 
+//SyncSpec defines attributes related to the git-sync container itself
+type SyncSpec struct {
+	Image   string            `json:"image,omitempty"`
+	Version string            `json:"tag,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
 //GitSpec defines the atributed needed to sync from a git repo
 type GitSpec struct {
 	// Repo describes the http/ssh uri for git repo
@@ -279,10 +286,8 @@ type GitSpec struct {
 	VerifySsl *bool `json:"verify,omitempty"`
 	// Reference to git credentials (user, password, ssh etc)
 	CredSecretRef *corev1.LocalObjectReference `json:"cred,omitempty"`
-	// git-sync image config + tag to use
-	SyncImage   string            `json:"syncImage,omitempty"`
-	SyncVersion string            `json:"syncTag,omitempty"`
-	SyncEnv     map[string]string `json:"syncEnv,omitempty"`
+	// Reference to git-sync image specific configuration
+	Sync *SyncSpec `json:"sync,omitempty"`
 }
 
 func (s *GitSpec) validate(fp *field.Path) field.ErrorList {

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -695,16 +695,18 @@ spec:
                       description: Configure git to ignore ssl (for use with self-signed
                         certs), false to ignore
                       type: boolean
-                    syncImage:
-                      description: Image to use for git-sync
-                      type: string
-                    syncTag:
-                      description: Tag to use for git-sync image
-                      type: string
-                    syncEnv:
-                      additionalProperties:
-                        type: string
-                      description: kv pairs of env vars to set in the git-sync container 
+                    sync:
+                      description: git-sync container related config
+                      properties:
+                        image:
+                          type: string
+                        tag:
+                          type: string
+                        env:
+                          additionalProperties:
+                            type: string
+                          description: kv pairs of env vars to set in the git-sync container 
+                          type: object
                       type: object
                   required:
                   - repo

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -704,8 +704,7 @@ spec:
                     sync-env:
                       additionalProperties:
                         type: string
-                      description: Airflow defines a list of kv pairs that describe env
-                        variables injected into the nodes
+                      description: kv pairs of env vars to set in the git-sync container 
                       type: object
                   required:
                   - repo

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -691,6 +691,12 @@ spec:
                     user:
                       description: User for git access
                       type: string
+                    sync-image:
+                      description: Image to use for git-sync
+                      type: string
+                    sync-tag:
+                      description: Tag to use for git-sync image
+                      type: string
                   required:
                   - repo
                   type: object

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -701,6 +701,12 @@ spec:
                     sync-tag:
                       description: Tag to use for git-sync image
                       type: string
+                    sync-env:
+                      additionalProperties:
+                        type: string
+                      description: Airflow defines a list of kv pairs that describe env
+                        variables injected into the nodes
+                      type: object
                   required:
                   - repo
                   type: object

--- a/config/crd/bases/airflow.apache.org_airflowclusters.yaml
+++ b/config/crd/bases/airflow.apache.org_airflowclusters.yaml
@@ -695,13 +695,13 @@ spec:
                       description: Configure git to ignore ssl (for use with self-signed
                         certs), false to ignore
                       type: boolean
-                    sync-image:
+                    syncImage:
                       description: Image to use for git-sync
                       type: string
-                    sync-tag:
+                    syncTag:
                       description: Tag to use for git-sync image
                       type: string
-                    sync-env:
+                    syncEnv:
                       additionalProperties:
                         type: string
                       description: kv pairs of env vars to set in the git-sync container 

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -617,6 +617,7 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 		{Name: "GIT_SYNC_ROOT", Value: "/tmp/git"},
 		{Name: "GIT_SYNC_ONE_TIME", Value: strconv.FormatBool(s.Once)},
 		{Name: "GIT_SYNC_REV", Value: s.Rev},
+		{Name: "HOME", Value: "/tmp"},
 	}
 	if s.CredSecretRef != nil {
 		env = append(env, []corev1.EnvVar{

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -613,6 +613,7 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 		{Name: "GIT_SYNC_REPO", Value: s.Repo},
 		{Name: "GIT_SYNC_DEST", Value: gitSyncDestDir},
 		{Name: "GIT_SYNC_BRANCH", Value: s.Branch},
+		{Name: "GIT_SYNC_ROOT", Value: "/tmp/git"},
 		{Name: "GIT_SYNC_ONE_TIME", Value: strconv.FormatBool(s.Once)},
 		{Name: "GIT_SYNC_REV", Value: s.Rev},
 	}

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -626,9 +626,17 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 	if s.Once {
 		init = true
 	}
+
+	// default to constant supplied by operator
+	image := alpha1.GitsyncImage + ":" + alpha1.GitsyncVersion
+
+	if s.SyncImage != "" && s.SyncVersion != "" {
+		image = s.SyncImage + ":" + s.SyncVersion
+	}
+
 	container = corev1.Container{
 		Name:    "git-sync",
-		Image:   alpha1.GitsyncImage + ":" + alpha1.GitsyncVersion,
+		Image:   image,
 		Env:     env,
 		Command: []string{"/git-sync"},
 		Ports: []corev1.ContainerPort{

--- a/controllers/airflowcluster_controller.go
+++ b/controllers/airflowcluster_controller.go
@@ -630,6 +630,16 @@ func gitContainer(s *alpha1.GitSpec, volName string) (bool, corev1.Container) {
 			}...)
 		}
 	}
+	// do final env configuration via git-sync env overide option
+	var keys []string
+	for k := range s.SyncEnv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		env = append(env, corev1.EnvVar{Name: k, Value: s.SyncEnv[k]})
+	}
+
 	if s.Once {
 		init = true
 	}

--- a/templates/airflow-configmap.yaml
+++ b/templates/airflow-configmap.yaml
@@ -199,8 +199,8 @@ data:
     gcp_service_account_keys =
 
     # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
-    git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
-    git_sync_container_tag = v2.0.5
+    git_sync_container_repository = k8s.gcr.io/git-sync/git-sync
+    git_sync_container_tag = v3.2.2
     git_sync_init_container_name = git-sync-clone
 
     [kubernetes_node_selectors]


### PR DESCRIPTION
This modifies the AirflowCluster CRD to make the `git-sync` image used configurable, also version bumps the existing image and points it to the new upstream location.