### PR TITLE
WIP: Create Dockerfile for ubi base images for use in OpenShift

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV PATH="${PATH}:/manager"
 RUN mkdir /manager

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,32 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.13.15 as builder
+
+WORKDIR /opt/app-root/src
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+FROM registry.access.redhat.com/ubi8-minimal
+
+ENV PATH="${PATH}:/manager"
+RUN mkdir /manager
+
+WORKDIR /manager
+COPY templates/ templates/
+COPY --from=builder /opt/app-root/src/manager .
+
+USER 1001
+
+ENTRYPOINT ["manager"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ ifndef NOTGCP
   SHORT_SHA := $(shell git rev-parse --short HEAD)
   IMG ?= gcr.io/${PROJECT_ID}/airflow-operator:${SHORT_SHA}
 endif
-
+DOCKERFILE := Dockerfile
+IMAGE_BUILDER := docker
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -74,13 +75,13 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	${IMAGE_BUILDER} build -f ${DOCKERFILE} . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	cd config/manager && kustomize edit set image controller=${IMG}
 
 # Push the docker image
 docker-push: docker-build
-	docker push ${IMG}
+	${IMAGE_BUILDER} push ${IMG}
 
 
 e2e-test:

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,9 +28,7 @@ make docker-build
 # push docker image
 make docker-push
 ```
-
-
-### Non GCP
+#### Non GCP
 Set IMG env to point to the desired registry image.
 ```bash
 # building docker image
@@ -39,6 +37,17 @@ make docker-build NOTGCP=true
 # push docker image
 make docker-push NOTGCP=true
 ```
+#### OpenShift
+Set DOCKERFILE to use ubi and IMG env to point to the desired registry image.
+```bash
+# building docker image
+# If you need to use a different image builder like podman/buildah, you can specify it in an optional argument IMG_BUILDER argument
+make docker-build DOCKERFILE=Dockerfile.ubi IMG_BUILDER=podman NOTGCP=true IMG=quay.io/my-registry/my-img-repository:v1.2.3
+
+# push docker image
+make docker-push IMG_BUILDER=podman NOTGCP=true IMG=quay.io/my-registry/my-img-repository:v1.2.3
+```
+
 ## Running in cluster
 ```bash
 # assumes kubeconfig is setup correctly

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,6 +32,7 @@ $ export IMG=gcr.io/myproject/airflow-controller:latest
 # Build and push
 $ make docker-push
 ```
+Refer to the [development docs](development.md#openshift) for instructions on building and deploying on OpenShift.
 
 ### Deploying Airflow Operator using manifests
 


### PR DESCRIPTION
## Related Issues and Dependencies

## This introduces a breaking change

- [X] Yes
- [ ] No


## This Pull Request implements

Creates a Dockerfile that use Red Hat ubi8 images for building the operator. This allows for building with images that have better support when running in OpenShift and alleviates any issues when builds fail due to docker rate limit issues.

## Description
The new `Dockerfile.ubi` uses `ubi8/go-toolset:1.13.15` as the builder image and `ubi8/ubi-minimal` as the operator base image
