### PR TITLE
Corrected volumeMounts in mysql and postgres templates

### DIFF
--- a/templates/mysql-sts.yaml
+++ b/templates/mysql-sts.yaml
@@ -109,7 +109,7 @@ spec:
         resources: {}
         volumeMounts:
         - name: data
-          mountPath: /var/lib/mysql
+          mountPath: /var/lib/mysql/data
       restartPolicy: Always
       {{if .Base.Spec.MySQL.VolumeClaimTemplate}}
       {{else}}

--- a/templates/postgres-sts.yaml
+++ b/templates/postgres-sts.yaml
@@ -68,7 +68,7 @@ spec:
           name: postgres
         volumeMounts:
         - name: data
-          mountPath: /var/lib/postgres/data
+          mountPath: /var/lib/pgsql/data
       restartPolicy: Always
       {{if .Base.Spec.Postgres.VolumeClaimTemplate}}
       {{else}}


### PR DESCRIPTION
## This Pull Request implements

Enables persistent storage for postgres and mysql images for SCL database images

## Description

The current `mountPath` for data directories for postgres and mysql images are not mounted into directories in use by SCL images. Without this change, persistent storage is not possible.
